### PR TITLE
CPS Integration

### DIFF
--- a/inocybe_dhcp/dhcpio.py
+++ b/inocybe_dhcp/dhcpio.py
@@ -188,7 +188,7 @@ class DHCPIo(object):
 
     def del_if(self, iface):
         '''Remove an interface from the monitored set'''
-        del self.ifaces_by_fd[self.ifaces[iface].rawio]
+        del self.ifaces_by_fd[self.ifaces[iface].rawio.fileno()]
         del self.ifaces[iface]
         logging.debug("Interface %s deleted", iface)
 

--- a/inocybe_dhcp/opx_dhcp.py
+++ b/inocybe_dhcp/opx_dhcp.py
@@ -44,12 +44,12 @@ DO_NOT_RELAY = 0
 UDP_RELAY = 1
 MITM_RELAY = 3
 
-MODULE = "dhcp-agent/if/interfaces/interface"
+MODULE = "dhcp-AGENT/if/interfaces/interface"
 IFROOT = "if/interfaces/interface"
 IFNAME = "if/interfaces/interface/name"
-DHCPPATH = "dhcp-agent/if/interfaces/interface"
-DHCPSERVER = "dhcp-agent/if/interfaces/interface/dhcp-server"
-DHCPTRUSTED = "dhcp-agent/if/interfaces/interface/trusted"
+DHCPPATH = "dhcp-AGENT/if/interfaces/interface"
+DHCPSERVER = "dhcp-AGENT/if/interfaces/interface/dhcp-server"
+DHCPTRUSTED = "dhcp-AGENT/if/interfaces/interface/trusted"
 
 
 # Initial assumption is that CPS will do a bound method as
@@ -63,20 +63,17 @@ DHCPTRUSTED = "dhcp-agent/if/interfaces/interface/trusted"
 # it is the job of the config callback to digest the incoming
 # data and convert into a suitable format
 
-agent = None
+AGENT = None
 
 def get_cb(method, params):
     '''CPS get callback'''
-    global agent
     fobj = cps_object.CPSObject(obj=params['filter'])
-    params['list'].extend(agent.get(fobj.get()))
+    params['list'].extend(AGENT.get(fobj.get()))
     return True
 
 def trans_cb(method, params):
     '''CPS transaction callback'''
-    global agent
-    tobj = cps_object.CPSObject(obj=params['change'])
-    return agent.transaction(params['change'])
+    return AGENT.transaction(params['change'])
 
 class Agent(object):
     '''DHCP Agent top level'''
@@ -97,75 +94,64 @@ class Agent(object):
             self._pending_config, self._active_config = None, self._pending_config
             self._process_config()
 
+    @staticmethod
+    def _narrow_by(sfilter):
+        '''Extract if/interface/interfaces/name from filter'''
+        try:
+            return cps_utils.cps_attr_types_map.from_data(
+                IFNAME,
+                sfilter['data'][IFNAME])
+        except KeyError:
+            return None
+
     def get(self, sfilter):
         '''Get config, filtering for a particular key'''
-        narrow_by = None
+        narrow_by = self._narrow_by(sfilter)
         result = []
-        try:
-            narrow_by = cps_utils.cps_attr_types_map.from_data(
-                    IFNAME,
-                    sfilter['data'][IFNAME]
-                    )
-        except KeyError:
-            pass
         for iface in self._active_config:
             if (narrow_by is None) or (iface["name"] == narrow_by):
                 try:
-                    obj =  cps_object.CPSObject(module=MODULE,
-                            data = {"dhcp-server":iface["dhcp-server"]})
+                    obj = cps_object.CPSObject(
+                        module=MODULE, data={"dhcp-server":iface["dhcp-server"]})
                 except KeyError:
-                    obj =  cps_object.CPSObject(module=MODULE,
-                            data = {"trusted":iface["trusted"].encode('ascii')})
+                    obj = cps_object.CPSObject(
+                        module=MODULE, data={"trusted":iface["trusted"].encode('ascii')})
                 result.append(obj.get())
         return result
 
     def transaction(self, change):
         '''Transaction handler'''
-        op_map = {"set": agent._set, "create": agent._create, "delete": agent._delete}
+        op_map = {"set": self._set, "create": self._create, "delete": self._delete}
         return op_map[change['operation']](change)
 
-        
     def _delete(self, change):
         '''Delete a config entry'''
-        narrow_by = None
-        result = []
-        try:
-            narrow_by = cps_utils.cps_attr_types_map.from_data(
-                    IFNAME,
-                    change['data'][IFNAME]
-                    )
-        except KeyError:
+        narrow_by = self._narrow_by(change)
+        if narrow_by is None:
             return False # we need an interface to be able to create
-
         new_config = []
         result = False
 
-        for iface in agent._active_config: 
+        for iface in self._active_config:
             if iface["name"] != narrow_by:
                 new_config.append(iface)
             else:
                 result = True
         if result:
-            agent._pending_config = new_config
+            self._pending_config = new_config
         return result
 
     def _create(self, change):
         '''Create entry in config'''
-        narrow_by = None
-        result = []
-        try:
-            narrow_by = cps_utils.cps_attr_types_map.from_data(
-                    IFNAME,
-                    change['data'][IFNAME]
-                    )
-        except KeyError:
+        narrow_by = self._narrow_by(change)
+        if narrow_by is None:
             return False # we need an interface to be able to create
 
         new_config = copy.deepcopy(self._active_config)
         if new_config is None:
             new_config = []
 
-        for iface in new_config: 
+        for iface in new_config:
             if (narrow_by is None) or (iface["name"] == narrow_by):
                 return False
         iface = {"name": narrow_by}
@@ -180,27 +166,18 @@ class Agent(object):
                 change['data'][DHCPTRUSTED]
             )
         new_config.append(iface)
-        agent._pending_config = new_config
+        self._pending_config = new_config
         return True
 
     def _set(self, change):
         '''Set entry in config for a particular key'''
 
-        narrow_by = None
-        result = []
-        try:
-            narrow_by = cps_utils.cps_attr_types_map.from_data(
-                    IFNAME,
-                    change['data'][IFNAME]
-                    )
-        except KeyError:
-            pass
-
+        narrow_by = self._narrow_by(change)
         new_config = copy.deepcopy(self._active_config)
         if new_config is None:
             new_config = []
 
-        for iface in new_config: 
+        for iface in new_config:
             if (narrow_by is None) or (iface["name"] == narrow_by):
                 iface.pop("dhcp-server", None)
                 iface.pop("trusted", None)
@@ -214,10 +191,10 @@ class Agent(object):
                         DHCPTRUSTED,
                         change['data'][DHCPTRUSTED]
                     )
-                agent._pending_config = new_config
+                self._pending_config = new_config
                 return True
         return False
-        
+
     # pylint: disable=unused-argument
     def mock_callback(self, signum, frame):
         '''Mock config read'''
@@ -363,26 +340,31 @@ class Agent(object):
 ### MAIN ###
 
 def main():
-    '''Run the dhcp agent'''
-    global agent
-    cps_utils.add_attr_type('dhcp-agent/if/interfaces/interface/dhcp-server','ipv4')
+    '''Run the dhcp AGENT'''
+    # I actually mean to use it - not worth it building a singleton for
+    # a single use
+    # pylint: disable=global-statement
+    global AGENT
+    cps_utils.add_attr_type('dhcp-AGENT/if/interfaces/interface/dhcp-server', 'ipv4')
     aparser = ArgumentParser(description=main.__doc__)
     aparser.add_argument(
         '--file',
-        help='the file containing the dhcp agent config if used in mock mode',
+        help='the file containing the dhcp AGENT config if used in mock mode',
         type=str)
     aparser.add_argument('--verbose', help='verbosity level', type=int)
     args = vars(aparser.parse_args())
     if args.get('verbose') is not None:
         logging.getLogger().setLevel(logging.DEBUG)
-    agent = Agent(mock=args.get("file"))
-
+    AGENT = Agent(mock=args.get("file"))
     dict_cb = {"get": get_cb, "transaction": trans_cb}
-    handle = cps.obj_init()
-    cps.obj_register(handle, cps.key_from_name("target", DHCPPATH) , dict_cb)
 
-    
-    agent.main_loop()
+    # disable cps pylint warnings - they are spurious
+    # pylint: disable=no-member
+    handle = cps.obj_init()
+    # pylint: disable=no-member
+    cps.obj_register(handle, cps.key_from_name("target", DHCPPATH), dict_cb)
+
+    AGENT.main_loop()
 
 if __name__ == '__main__':
     main()

--- a/model/dhcp-agent.yang
+++ b/model/dhcp-agent.yang
@@ -1,0 +1,360 @@
+module dhcp-agent {
+
+    namespace "urn:ietf:params:xml:ns:yang:dhcp-agent";
+    prefix dhcp-agent;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+    import ietf-interfaces {
+        prefix if;
+    }
+    import dell-base-common { prefix "base-cmn"; }
+    import iana-if-type { prefix "ianaift"; }
+
+    organization "Inocybe Technologies";
+
+    contact "Anton Ivanov <anton.ivanov@cambridgegreys.com>";
+
+    description
+        "This module contains a set of definitions to control
+         a programmable Layer2 switch DHCP agent and/or DHCP Relay.";
+
+    revision 2018-04-26 {
+        description "Initial revision.";
+    }
+
+    typedef comparison-operation {
+        type enumeration {
+            enum "EQ" {
+                value 0;
+            }
+            enum "GE" {
+                value 1;
+            }
+            enum "LE" {
+                value 2;
+            }
+            enum "G" {
+                value 3;
+            }
+            enum "L" {
+                value 4;
+            }
+            enum "AND" {
+                value 5;
+            }
+            enum "OR" {
+                value 6;
+            }
+            enum "GLOB" {
+                description
+                    "Return true regardless of values - intended for additions";
+                value 7;
+            }
+        }
+    }
+
+    typedef which-direction {
+        type enumeration {
+            enum "UP" {
+                description "To Server";
+                value 0;
+            }
+            enum "DOWN" {
+                description "To Client";
+                value 1;
+            }
+        }
+    }
+    grouping dhcp-option {
+        description "Format of DHCP options"; 
+        leaf dhcp-option-code {
+            type uint8;
+            mandatory true;
+            description "DHCP Option Code";
+        }
+        choice option-type {
+            case void-option {
+            }
+            case inet-option {
+                leaf inet {
+                    type base-cmn:ip-address;
+                    description "An IPv4 Address";
+                }
+            }
+            case inet-list {
+                list inets {
+                    key "order";
+                    description "A list of IPv4 Addresses";
+                    leaf order {
+                        type uint8; 
+                        description "Dummy number used to order the list";
+                    }
+                    leaf address {
+                        type base-cmn:ip-address;
+                        description "An IPv4 Address";
+                    }
+                }
+            }
+            case inet-paired-list {
+                list paired-inets {
+                    key "order";
+                    description "A list of IPv4 Addresses";
+                    leaf order {
+                        type uint8; 
+                        description "Dummy number used to order the list";
+                    }
+                    leaf address-1 {
+                        type base-cmn:ip-address;
+                        description "An IPv4 Address";
+                    }
+                    leaf address-2 {
+                        type base-cmn:ip-address;
+                        description "An IPv4 Address";
+                    }
+                }
+            }
+            case integer {
+                leaf int-value {
+                    type uint32; 
+                    description "32 bit integer value";
+                }
+            }
+            case short {
+                leaf short-value {
+                    type uint16; 
+                    description "16 bit integer value";
+                }
+            }
+            case short-list {
+                leaf-list short-value-list {
+                    type uint16; 
+                    description "list of 16 bit integer values";
+                }
+            }
+            case byte {
+                leaf byte-value {
+                    type uint8; 
+                    description "8 bit integer value";
+                }
+            }
+            case byte-list {
+                leaf-list byte-value-list {
+                    type uint8; 
+                    description "List of 8 bit integer values";
+                }
+            }
+            case string {
+                leaf-list string-value {
+                    type string; 
+                    description "String option value";
+                }
+            }
+            case relays {
+                list relay-option-values {
+                    key "relay-option";
+                    description "A list of Relay Agent Options";
+                    leaf relay-option {
+                        type uint8; 
+                        description "Relay Option Code";
+                    }
+                    leaf value {
+                        type string;
+                        description "Relay Option Value";
+                    }
+                }
+            }
+            case client-identifier {
+                container ids {
+                    leaf hardware-type {
+                        type uint8;
+                        description "Hardware Type"; 
+                    }
+                    leaf string {
+                        type string; 
+                        description "Hardware address";
+                    }
+                }
+            }
+            
+            case csr {
+                leaf csr {
+                    type inet:ipv4-prefix; 
+                    description "IPv4 Prefix (leave the conversion to serialization)"; 
+                }
+            }
+            case binary {
+                leaf bin-value {
+                    type binary;
+                    description "Catch-all for everything else which we do not know";
+                }
+            }
+            /*
+            suboptions : hex encoded sub options
+            */
+        }
+    }
+
+    grouping dhcp-packet {
+        description "Format of DHCP Packet";
+        leaf op {
+            type uint8;
+            description "BOOTP op";
+        }
+        leaf htype {
+            type uint8;
+            description "Hardware Type";
+        }
+        leaf hlen {
+            type uint8;
+            description "Hardware Address Length";
+        }
+        leaf hops {
+            type uint8;
+            description "Relay Agent Hops";
+        }
+        leaf xid {
+            type uint32;
+            description "Xid";
+        }
+        leaf secs {
+            type uint16;
+            description "Seconds since the start of configuration";
+        }
+        leaf flags {
+            type uint16;
+            description "Flags - Broadcast or Unicast for reply";
+        }
+        leaf ciaddr {
+            type base-cmn:ip-address;
+            description "Client IP Address";
+        }
+        leaf yiaddr {
+            type base-cmn:ip-address;
+            description "Your (client) IP address";
+        }
+        leaf siaddr {
+            type base-cmn:ip-address;
+            description "Next Server address";
+        }
+        leaf giaddr {
+            type base-cmn:ip-address;
+            description "Relay Address";
+        }
+        leaf chaddr {
+            type binary;
+            description "Client Hardware Address";
+        }
+        leaf sname {
+            type string;
+            description "Server Name";
+        }
+        leaf file {
+            type string;
+            description "Boot File Name";
+        }
+        list dhcp-options {
+            key "option-order";
+            leaf option-order {
+                type uint8;
+                description "Dummy ordering field to order the list";
+            }
+            uses dhcp-option;
+        }
+    }
+
+    grouping comparison-data {
+        leaf operation {
+            type comparison-operation;
+            description "Operation for comparison";
+        }
+
+        leaf list-operation {
+            type comparison-operation;
+            description "Operation for comparison - list form options";
+        }
+
+        leaf direction {
+            type which-direction;
+            description "When to apply the processing";
+        }
+
+        uses dhcp-packet;
+    }
+
+
+
+    /*
+    * Configuration data nodes
+    */
+
+    augment "/if:interfaces/if:interface" {
+        when "if:type = 'ianaift:l2vlan'";
+
+            leaf dhcp-server {
+            type base-cmn:ip-address;
+            description
+                "A Server to forward requests for this interface when
+                 operating as a DHCP Relay.
+                 If this leaf is null, the agent will change the requests
+                 transparently before forwarding them at Layer 2.";
+            }
+
+            leaf trusted {
+            type string;
+            description
+                "A trusted interface for forwarding requests which have been
+                 snooped in MitM mode";
+            }
+            list delete {
+                key "priority";
+                description 
+                "Options to delete
+
+                 The implementation scans the dhcp data and selects an
+                 an option to delete. 
+
+                 Specifying only the option code will delete 
+                 regardless of value and comparison operation. 
+
+                 Specifying option values will use the 
+                 comparison-operation from op on the option data.
+                 If the option data is a list, the operation will be
+                 performed on all elements and accumulated according
+                 to list-op.
+                 If the comparison operation yields a true value, the
+                 option will be deleted.
+                ";
+                leaf priority {
+                    type uint32;
+                    description "Defines the order in which the rules are executed";
+                }
+                uses comparison-data;
+
+            }
+            list add {
+                key "priority";
+                description 
+                "Options to add
+                 The implementation scans the dhcp data using the same semantics as for
+                 delete. If the search returns true, the list of additions is executed.
+                ";
+                leaf priority {
+                    type uint32;
+                    description "Defines the order in which the rules are executed";
+                }
+                
+                uses comparison-data;
+
+                list additions {
+                    key "order";
+                    leaf order {
+                        type uint32;
+                        description "Defines the order in which the additions are processed";
+                    }
+                    uses dhcp-packet;
+                }
+            }
+        }
+}


### PR DESCRIPTION
Integrates to CPS subject to the limitations of the opx-cps Issue #84

get, set, create and delete are supported.

Supports only basic option 82 type 1 and relay/snooping on an interface same as the agent so far.

Provides model for managing the agent.