### PR TITLE
Fix regression in relay code

### DIFF
--- a/inocybe_dhcp/dhcpio.py
+++ b/inocybe_dhcp/dhcpio.py
@@ -36,8 +36,8 @@ MAXPACKET = 1500
 FILTER = "udp and (dst port 68) or (dst port 67)"
 ETH_BROADCAST = '\xff\xff\xff\xff\xff\xff'
 
-def print_mac(data):
-    '''Print out an IP addr as numeric'''
+def format_mac(data):
+    '''Print out a MAC addr in standard text form'''
     try:
         mac0, mac1, mac2, mac3, mac4, mac5 = struct.unpack("BBBBBB", data)
         return "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}".format(
@@ -45,8 +45,8 @@ def print_mac(data):
     except struct.error:
         return "{}".format(data)
 
-def print_ip(data):
-    '''Print out an IP addr as numeric'''
+def format_ip(data):
+    '''Print out an IP addr as a dotted quad'''
     try:
         ip0, ip1, ip2, ip3 = struct.unpack("BBBB", data)
         return "{}.{}.{}.{}".format(ip0, ip1, ip2, ip3)
@@ -147,11 +147,11 @@ class Ifinfo(object):
         )
         if to_server:
             logging.debug("Raw socket to server on %s using %s/%s",
-                          self.iface, print_ip(ipaddr), print_mac(mac))
+                          self.iface, format_ip(ipaddr), format_mac(mac))
             self.trust_sock.send(str(eth))
         else:
             logging.debug("Raw socket to client on %s using %s/%s",
-                          self.iface, print_ip(ipaddr), print_mac(mac))
+                          self.iface, format_ip(ipaddr), format_mac(mac))
             self.rawio.write(str(eth))
             self.rawio.flush() # needed, otherwise python buffering messes it up
 

--- a/inocybe_dhcp/dhcpio.py
+++ b/inocybe_dhcp/dhcpio.py
@@ -77,6 +77,8 @@ class Ifinfo(object):
         # pylint: disable=unused-variable
         except (IndexError, KeyError) as ignore:
             self.ipaddr = None
+        if self.ipaddr == None and trusted is None:
+            raise ValueError("Relay mode requires a v4 address on interface")
         # pylint: disable=no-member
         self.mac = ni.ifaddresses(iface)[ni.AF_PACKET][0]['addr']
         self.rawio = os.fdopen(self.pcap.fileno(), "w+")

--- a/inocybe_dhcp/dhcpio.py
+++ b/inocybe_dhcp/dhcpio.py
@@ -38,14 +38,21 @@ ETH_BROADCAST = '\xff\xff\xff\xff\xff\xff'
 
 def print_mac(data):
     '''Print out an IP addr as numeric'''
-    mac0, mac1, mac2, mac3, mac4, mac5 = struct.unpack("BBBBBB", data)
-    return "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}".format(
-        mac0, mac1, mac2, mac3, mac4, mac5)
+    try:
+        mac0, mac1, mac2, mac3, mac4, mac5 = struct.unpack("BBBBBB", data)
+        return "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}".format(
+            mac0, mac1, mac2, mac3, mac4, mac5)
+    except struct.error:
+        return "{}".format(data)
 
 def print_ip(data):
     '''Print out an IP addr as numeric'''
-    ip0, ip1, ip2, ip3 = struct.unpack("BBBB", data)
-    return "{}.{}.{}.{}".format(ip0, ip1, ip2, ip3)
+    try:
+        ip0, ip1, ip2, ip3 = struct.unpack("BBBB", data)
+        return "{}.{}.{}.{}".format(ip0, ip1, ip2, ip3)
+    except struct.error:
+        return "{}".format(data)
+
 
 
 class Ifinfo(object):

--- a/inocybe_dhcp/opx_dhcp.py
+++ b/inocybe_dhcp/opx_dhcp.py
@@ -26,8 +26,8 @@ import copy
 from argparse import ArgumentParser
 from inocybe_dhcp.dhcpio import DHCPIo
 from inocybe_dhcp.dhcpio import DHCPSERVER
-from inocybe_dhcp.dhcpio import print_ip
-from inocybe_dhcp.dhcpio import print_mac
+from inocybe_dhcp.dhcpio import format_ip
+from inocybe_dhcp.dhcpio import format_mac
 from inocybe_dhcp.rfc2131 import Message as DhcpMessage
 from inocybe_dhcp.options import BuiltIn as DhcpOptions
 from inocybe_dhcp.rfc3046 import RelayAgentInformation
@@ -292,8 +292,8 @@ class Agent(object):
             if parsed["op"] == BOOTREQUEST:
                 relay = MITM_RELAY
         logging.debug("Processing complete for %s from %s @ %s %s",
-                      parsed, print_ip(src_ip),
-                      print_mac(src_mac), relay)
+                      parsed, format_ip(src_ip),
+                      format_mac(src_mac), relay)
         return (parsed.pack(), ifinfo, src_ip, src_mac, relay)
 
 

--- a/inocybe_dhcp/opx_dhcp.py
+++ b/inocybe_dhcp/opx_dhcp.py
@@ -284,7 +284,7 @@ class Agent(object):
 
         # packet processing goes in here
         # insert giaddr option for relay mode
-        if ifinfo.dst is not None:
+        if ifinfo.dst is not None and ifinfo.ipaddr is not None:
             if parsed["op"] == BOOTREQUEST:
                 parsed['giaddr'] = ifinfo.ipaddr
                 relay = UDP_RELAY


### PR DESCRIPTION
A regression to the relay code was introduced as a result
of adding some of the agent/mitm code. This commit fixes it.

Additionally, this commit adds debug and tracing to the cps code
paths.

Signed-off-by: Anton Ivanov <anton.ivanov@cambridgegreys.com>